### PR TITLE
fix: run axe after turning interactive mode off

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -190,7 +190,7 @@ export default function AxeMode({ children, disabled }: AxeModeProps) {
   const childrenRef = React.useRef<HTMLElement | null>(null);
 
   React.useEffect(() => {
-    if (disabled) {
+    if (disabled || interactive) {
       return;
     }
 
@@ -211,7 +211,7 @@ export default function AxeMode({ children, disabled }: AxeModeProps) {
       });
       setIdleId(id);
     }
-  }, [children, disabled]);
+  }, [children, disabled, interactive]);
 
   React.useEffect(() => {
     function listener(e: KeyboardEvent) {


### PR DESCRIPTION
Fixes a small bug where nodes that appear after interacting with the application would not appear.

![gif](https://i.gyazo.com/d981e48ae8a0732b3559f6c35e3b320a.gif)