### PR TITLE
fix: only run requestIdleCallback if it exists

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -29,7 +29,10 @@ const App = () => {
           <h6>Accessibility testing componentized</h6>
           <input placeholder="Username" />
           <input placeholder="Password" />
-          <button aria-expanded="foo" onClick={() => console.log('yo')}>
+          <button
+            aria-expanded={'foo' as any}
+            onClick={() => console.log('yo')}
+          >
             Label
           </button>
         </div>

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "eslintConfig": {
     "extends": "react-app",
-    "// We have intentional violations in the example for testing, so we can turn off jsx-a11y rules for them only": "",
     "overrides": [
       {
         "files": [

--- a/package.json
+++ b/package.json
@@ -50,5 +50,21 @@
     "@reach/observe-rect": "^1.1.0",
     "@reach/popover": "^0.10.1",
     "axe-core": "^3.5.3"
+  },
+  "eslintConfig": {
+    "extends": "react-app",
+    "// We have intentional violations in the example for testing, so we can turn off jsx-a11y rules for them only": "",
+    "overrides": [
+      {
+        "files": [
+          "example/*"
+        ],
+        "rules": {
+          "jsx-a11y/alt-text": 0,
+          "jsx-a11y/anchor-is-valid": 0,
+          "jsx-a11y/accessible-emoji": 0
+        }
+      }
+    ]
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -185,7 +185,7 @@ export interface AxeModeProps {
 
 export default function AxeMode({ children, disabled }: AxeModeProps) {
   const [violations, setViolations] = React.useState<Result[]>([]);
-  const [idleId, setIdleId] = React.useState(null);
+  const idleId = React.useRef<number | null>(null);
   const [interactive, setInteractive] = React.useState(false);
   const childrenRef = React.useRef<HTMLElement | null>(null);
 
@@ -195,28 +195,26 @@ export default function AxeMode({ children, disabled }: AxeModeProps) {
     }
 
     if (childrenRef.current) {
-      if (idleId && 'cancelIdleCallback' in window) {
-        // requestIdleCallback has no types:
-        // https://github.com/microsoft/TypeScript/issues/21309
-        // @ts-ignore
-        cancelIdleCallback(idleId);
-        setIdleId(null);
-      }
-
-      function getViolations() {
-        validateNode(childrenRef.current as ElementContext).then(setViolations);
+      if (idleId.current && 'cancelIdleCallback' in window) {
+        window.cancelIdleCallback(idleId.current);
+        idleId.current = null;
       }
 
       // Safari does not support requestIdleCallback 😔
       if ('requestIdleCallback' in window) {
-        // requestIdleCallback has no types:
-        // https://github.com/microsoft/TypeScript/issues/21309
-        // @ts-ignore
-        const id = requestIdleCallback(getViolations);
-        setIdleId(id);
+        idleId.current = window.requestIdleCallback(getViolations);
       } else {
         getViolations();
       }
+    }
+    return () => {
+      if (idleId.current && 'cancelIdleCallback' in window) {
+        window.cancelIdleCallback(idleId.current);
+        idleId.current = null;
+      }
+    };
+    function getViolations() {
+      validateNode(childrenRef.current as ElementContext).then(setViolations);
     }
   }, [children, disabled]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -195,7 +195,7 @@ export default function AxeMode({ children, disabled }: AxeModeProps) {
     }
 
     if (childrenRef.current) {
-      if (idleId) {
+      if (idleId && 'cancelIdleCallback' in window) {
         // requestIdleCallback has no types:
         // https://github.com/microsoft/TypeScript/issues/21309
         // @ts-ignore
@@ -203,13 +203,20 @@ export default function AxeMode({ children, disabled }: AxeModeProps) {
         setIdleId(null);
       }
 
-      // requestIdleCallback has no types:
-      // https://github.com/microsoft/TypeScript/issues/21309
-      // @ts-ignore
-      const id = requestIdleCallback(() => {
+      function getViolations() {
         validateNode(childrenRef.current as ElementContext).then(setViolations);
-      });
-      setIdleId(id);
+      }
+
+      // Safari does not support requestIdleCallback 😔
+      if ('requestIdleCallback' in window) {
+        // requestIdleCallback has no types:
+        // https://github.com/microsoft/TypeScript/issues/21309
+        // @ts-ignore
+        const id = requestIdleCallback(getViolations);
+        setIdleId(id);
+      } else {
+        getViolations();
+      }
     }
   }, [children, disabled]);
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,19 @@
+type RequestIdleCallbackOptions = {
+  timeout: number;
+};
+type RequestIdleCallbackDeadline = {
+  readonly didTimeout: boolean;
+  timeRemaining: () => number;
+};
+
+declare global {
+  interface Window {
+    requestIdleCallback: (
+      callback: (deadline: RequestIdleCallbackDeadline) => void,
+      opts?: RequestIdleCallbackOptions
+    ) => number;
+    cancelIdleCallback: (handle: number) => void;
+  }
+}
+
+export {}


### PR DESCRIPTION
Currently, the app would crash in Safari because it [does not support `requestIdleCallback`](https://caniuse.com/#search=requestIdleCallback)

Maybe we should polyfill it or use an alternative if performance becomes an issue.