### PR TITLE
feat: catch DOM mutation violations

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -9,12 +9,24 @@ function Subtitle() {
 }
 
 function Image() {
+  const ref = React.useRef<HTMLImageElement | null>(null);
+
+  React.useEffect(() => {
+    // For testing whether violations from
+    // DOM mutations are displayed.
+    const id = setTimeout(() => {
+      ref?.current?.setAttribute('alt', 'Avatar');
+    }, 3000);
+
+    return () => clearTimeout(id);
+  }, [ref]);
+
   return (
     <img
+      ref={ref}
       src="https://avatars1.githubusercontent.com/u/23662329?v=4"
       width="40"
       height="40"
-      id="hey"
     />
   );
 }

--- a/src/axe-mode.tsx
+++ b/src/axe-mode.tsx
@@ -209,16 +209,21 @@ export default function AxeModeImpl({ children, disabled }: AxeModeProps) {
   const childrenRef = React.useRef<HTMLElement | null>(null);
 
   React.useEffect(() => {
-    if (disabled || interactive) {
+    if (disabled || interactive || !childrenRef.current) {
       return;
     }
 
-    if (childrenRef.current) {
-      if (idleId.current && 'cancelIdleCallback' in window) {
-        window.cancelIdleCallback(idleId.current);
-        idleId.current = null;
-      }
+    if (idleId.current && 'cancelIdleCallback' in window) {
+      window.cancelIdleCallback(idleId.current);
+      idleId.current = null;
+    }
 
+    function getViolations() {
+      const validateNode = getValidator(axe);
+      validateNode(childrenRef.current as ElementContext).then(setViolations);
+    }
+
+    function callback() {
       // Safari does not support requestIdleCallback 😔
       if ('requestIdleCallback' in window) {
         idleId.current = window.requestIdleCallback(getViolations);
@@ -226,17 +231,26 @@ export default function AxeModeImpl({ children, disabled }: AxeModeProps) {
         getViolations();
       }
     }
+
+    const observer = new MutationObserver(callback);
+    // We need to run this once so we don't wait for
+    // DOM mutations to display the violations.
+    callback();
+
+    observer.observe(childrenRef.current, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+
     return () => {
       if (idleId.current && 'cancelIdleCallback' in window) {
         window.cancelIdleCallback(idleId.current);
         idleId.current = null;
       }
+      observer.disconnect();
     };
-    function getViolations() {
-      const validateNode = getValidator(axe);
-      validateNode(childrenRef.current as ElementContext).then(setViolations);
-    }
-  }, [children, disabled, interactive, axe]);
+  }, [disabled, interactive]);
 
   React.useEffect(() => {
     function listener(e: KeyboardEvent) {

--- a/src/axe-mode.tsx
+++ b/src/axe-mode.tsx
@@ -92,6 +92,9 @@ function Violation({
       setOverlayPosition(overlayNode, targetRect);
     });
 
+    const bounds = targetNode.getBoundingClientRect();
+    setOverlayPosition(overlayNode, bounds);
+
     observe();
     document.body.appendChild(overlayNode);
     overlayNode.addEventListener('mousedown', toggle);


### PR DESCRIPTION
Closes #8

<hr />

For testing, I've added a trivial DOM mutation by asynchronously setting the `alt` tag on `img`. Generally, I think this works. Though, there's a weird bug that I can't figure out:

![gif](https://gyazo.com/5822ab9d7c08bd5c2010fdc813ffc66c.gif)

1. Refresh the page
2. All nodes are in violation
3. `img` gets a valid `alt` attribute after 3 seconds, thus it is no longer in violation
4. The overlays of `input` elements disappear

If I resize the window, the `input` overlays reappear. 

I think the problem is with observing the position of the overlay:

https://github.com/raunofreiberg/axe-mode/blob/57809ed8e5e1455653046e1f4cd350fbc4543b60/src/index.tsx#L88-L90

If I add this, the overlays persists its position:

```js
const bounds = targetNode.getBoundingClientRect();
setOverlayPosition(overlayNode, bounds);
```

@chancestrickland maybe you can shine some light here. I might be doing something wrong! 😄