### PR TITLE
feat: improve keyboard navigation of overlays

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -78,6 +78,12 @@ function Violation({
     setOpen(false);
   }
 
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      toggle();
+    }
+  }
+
   React.useEffect(() => {
     const targetNode = document.querySelector(target);
     const overlayNode = document.createElement('axe-mode-overlay');
@@ -91,12 +97,21 @@ function Violation({
 
     observe();
     document.body.appendChild(overlayNode);
+
+    targetNode.setAttribute('tabindex', '-1');
+    overlayNode.setAttribute('role', 'button');
+    overlayNode.setAttribute('tabindex', '0');
+
     overlayNode.addEventListener('mousedown', toggle);
+    overlayNode.addEventListener('keydown', handleKeydown);
+    overlayNode.addEventListener('blur', close);
 
     return () => {
       unobserve();
       document.body.removeChild(overlayNode);
       overlayNode.removeEventListener('mousedown', toggle);
+      overlayNode.removeEventListener('keydown', handleKeydown);
+      overlayNode.removeEventListener('blur', close);
     };
   }, [target]);
 


### PR DESCRIPTION
Trivial keyboard support for interacting with overlays.

I'm not sure how to properly define the order of elements in keyboard navigation. Currently, every overlay gets a `tabindex` of `0` so the sequence will be based on the violations that axe gives us, not the elements themselves. 

@chancestrickland maybe you have some ideas here?